### PR TITLE
🐛 FIX: JSONDecodeError catching

### DIFF
--- a/firecrest/BasicClient.py
+++ b/firecrest/BasicClient.py
@@ -5,9 +5,9 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 import itertools
-import json
 import jwt
 import requests
+from requests.compat import json
 import shlex
 import shutil
 import subprocess


### PR DESCRIPTION
requests uses simplejson, if installed, which leads to `JSONDecodeError` not being caught on `response.json()`
(for example, when using `simple_download`)