### PR TITLE
Add squeue polling method

### DIFF
--- a/firecrest/BasicClient.py
+++ b/firecrest/BasicClient.py
@@ -805,6 +805,27 @@ class Firecrest:
             json_response["task_id"], "200", itertools.cycle([1, 5, 10])
         )
 
+    def poll_active(self, machine, jobs=[]):
+        """Retrieves information about active jobs.
+        This call uses the `squeue -u <username>` command.
+
+        :param machine: the machine name where the scheduler belongs to
+        :type machine: string
+        :param jobs: list of the IDs of the jobs (default [])
+        :type jobs: list of strings/integers, optional
+        :calls: GET `/compute/jobs`
+
+                GET `/tasks/{taskid}`
+        :rtype: dictionary
+        """
+        self._current_method_requests = []
+        jobids = [str(j) for j in jobs]
+        json_response = self._squeue_request(machine, jobids)
+        dict_result = self._poll_tasks(
+            json_response["task_id"], "200", itertools.cycle([1, 5, 10])
+        )
+        return list(dict_result.values())
+
     def cancel(self, machine, jobid):
         """Retrieves information about submitted jobs.
         This call uses the `scancel` command.


### PR DESCRIPTION
Add a polling method that is using the [/compute/jobs endpoint](https://firecrest-api.cscs.ch/#/Compute/get_compute_jobs), in order to get information for active jobs with the `squeue` command.